### PR TITLE
Multiarch 64bit Package

### DIFF
--- a/ca.johnramsden.pathofexile.json
+++ b/ca.johnramsden.pathofexile.json
@@ -1,9 +1,9 @@
 {
     "app-id": "ca.johnramsden.pathofexile",
-    "branch": "master",
-    "runtime": "org.freedesktop.Platform/i386", 
-    "sdk": "org.freedesktop.Sdk/i386", 
-    "runtime-version": "1.6", 
+    "runtime": "org.freedesktop.Platform/x86_64", 
+    "sdk": "org.freedesktop.Sdk/x86_64", 
+    "runtime-version": "1.6",
+    "branch": "64bit",
     "tags": ["proprietary"],
     "command": "pathofexile.sh",
     "build-options": {
@@ -15,7 +15,7 @@
       }
     },
     "finish-args": [
-       "--persist=.local/share/pathofexile",
+       "--persist=.local/share/pathofexile_x64",
        "--socket=x11",
        "--share=network",
        "--share=ipc",
@@ -26,7 +26,8 @@
        "--filesystem=xdg-documents",
        "--env=WINEDEBUG=-all",
        "--env=WINE_RESOLUTION=1920x1080",
-       "--env=VIDEO_MEMORY="
+       "--env=VIDEO_MEMORY=",
+       "--env=WINE=/app/bin/wine64"
     ],
     "modules": [
         {
@@ -37,6 +38,8 @@
             "config-opts": [
                 "--libdir=/app/lib",
                 "--disable-win16",
+                "--disable-win32",
+                "--enable-win64",
                 "--with-x",
                 "--without-cups",
                 "--without-curses",
@@ -124,14 +127,14 @@
             "buildsystem": "simple",
             "build-commands": [
               "mkdir -p ${WINEPREFIX}",
-              "install -D wine_gecko-2.47-x86.msi /app/share/wine/gecko/wine_gecko-2.47-x86.msi"
+              "install -D wine_gecko-2.47-x86_64.msi /app/share/wine/gecko/wine_gecko-2.47-x86_64.msi"
             ],
             "no-make-install": true,
             "sources": [
                 {
                     "type": "file",
-                    "url": "http://dl.winehq.org/wine/wine-gecko/2.47/wine_gecko-2.47-x86.msi",
-                    "sha256": "3b8a361f5d63952d21caafd74e849a774994822fb96c5922b01d554f1677643a"
+                    "url": "http://dl.winehq.org/wine/wine-gecko/2.47/wine_gecko-2.47-x86_64.msi",
+                    "sha256": "c565ea25e50ea953937d4ab01299e4306da4a556946327d253ea9b28357e4a7d"
                 }
             ]
         },

--- a/ca.johnramsden.pathofexile.json
+++ b/ca.johnramsden.pathofexile.json
@@ -6,6 +6,13 @@
     "branch": "64bit",
     "tags": ["proprietary"],
     "command": "pathofexile.sh",
+    "add-build-extensions": {
+        "org.freedesktop.Platform.Compat32": {
+            "directory": "lib/32bit",
+            "add-ld-path": "lib",
+            "version": "1.6"
+        }
+    },
     "build-options": {
       "cflags": "-O1 -pipe",
       "env": {
@@ -28,9 +35,35 @@
        "--env=WINE_RESOLUTION=1920x1080",
        "--env=VIDEO_MEMORY=",
        "--env=WINE=/app/bin/wine",
-       "--env=LD_LIBRARY_PATH=/app/lib:/app/lib32"
+       "--env=LD_LIBRARY_PATH=/app/lib:/app/lib/32bit",
+       "--extension=org.freedesktop.Platform.Compat32=directory=lib/32bit",
+       "--extension=org.freedesktop.Platform.Compat32=version=1.6",
+       "--extension=org.freedesktop.Platform.GL32=directory=lib/32bit/lib/GL",
+       "--extension=org.freedesktop.Platform.GL32=version=1.4",
+       "--extension=org.freedesktop.Platform.GL32=versions=1.6;1.4",
+       "--extension=org.freedesktop.Platform.GL32=subdirectories=true",
+       "--extension=org.freedesktop.Platform.GL32=no-autodownload=true",
+       "--extension=org.freedesktop.Platform.GL32=autodelete=false",
+       "--extension=org.freedesktop.Platform.GL32=add-ld-path=lib",
+       "--extension=org.freedesktop.Platform.GL32=merge-dirs=vulkan/icd.d;glvnd/egl_vendor.d",
+       "--extension=org.freedesktop.Platform.GL32=download-if=active-gl-driver",
+       "--extension=org.freedesktop.Platform.GL32=enable-if=active-gl-driver"
     ],
     "modules": [
+        {
+            "name": "setup-32bit",
+            "buildsystem": "simple",
+            "build-commands": [
+                "ln -s /app/lib/32bit/lib/ld-linux.so.2 /app/lib/ld-linux.so.2",
+                "install -Dm644 ld.so.conf /app/etc/ld.so.conf"
+            ],
+            "sources": [
+                {
+                    "type": "file",
+                    "path": "ld.so.conf"
+                }
+            ]
+        },
         {
             "name": "wine",
             "buildsystem": "simple",

--- a/ca.johnramsden.pathofexile.json
+++ b/ca.johnramsden.pathofexile.json
@@ -27,30 +27,17 @@
        "--env=WINEDEBUG=-all",
        "--env=WINE_RESOLUTION=1920x1080",
        "--env=VIDEO_MEMORY=",
-       "--env=WINE=/app/bin/wine64"
+       "--env=WINE=/app/bin/wine",
+       "--env=LD_LIBRARY_PATH=/app/lib:/app/lib32"
     ],
     "modules": [
         {
             "name": "wine",
-            "build-options": {
-                "make-args": [ "--silent" ] 
-            },
-            "config-opts": [
-                "--libdir=/app/lib",
-                "--disable-win16",
-                "--disable-win32",
-                "--enable-win64",
-                "--with-x",
-                "--without-cups",
-                "--without-curses",
-                "--without-capi",
-                "--without-glu",
-                "--without-gphoto",
-                "--without-gsm",
-                "--without-hal",
-                "--without-ldap",
-                "--without-netapi"
+            "buildsystem": "simple",
+            "build-commands": [
+              "chmod +x winebuild.sh && ./winebuild.sh"
             ],
+            "no-make-install": true,
             "cleanup": [
                 "/bin/function_grep.pl",
                 "/bin/msiexec",
@@ -92,6 +79,10 @@
                 {
                     "type": "shell",
                     "commands": [ "./patches/patchinstall.sh DESTDIR=$(pwd) --all" ]
+                },
+                {
+                    "type": "file",
+                    "path": "winebuild.sh"
                 }
             ]
         },

--- a/ld.so.conf
+++ b/ld.so.conf
@@ -1,0 +1,3 @@
+# We just make any GL32 extension have higher priority
+include /run/flatpak/ld.so.conf.d/app-*-org.freedesktop.Platform.GL32.*.conf
+/app/lib/32bit/lib

--- a/pathofexile.sh
+++ b/pathofexile.sh
@@ -1,22 +1,22 @@
 #!/bin/bash
 
-export WINEPREFIX="${HOME}/.local/share/pathofexile"
+export WINEPREFIX="${HOME}/.local/share/pathofexile_x64"
 export WINEDEBUG=-all
 
 POE_INSTALLER_NAME="pathofexile_setup.exe"
 POE_SETUP="${WINEPREFIX}/${POE_INSTALLER_NAME}"
 POE_DOWNLOAD_URL='https://www.pathofexile.com/downloads/PathOfExileInstaller.exe'
-POE_RUN_CMD="${WINEPREFIX}/drive_c/Program Files/Grinding Gear Games/Path of Exile/PathOfExile.exe"
+POE_RUN_CMD="${WINEPREFIX}/drive_c/Program Files/Grinding Gear Games/Path of Exile/PathOfExile_x64.exe"
 
 WINE_RESOLUTION="${WINE_RESOLUTION:-1920x1080}"
 WINE="/app/bin/wine"
 
 XORG_LOG="/var/log/Xorg.0.log"
 
-VERSION_NUM="0.1.3"
+VERSION_NUM="0.2.0"
 VERSION_FILE="${WINEPREFIX}/ca.johnramsden.pathofexile.version"
 
-declare -ra WINE_PACKAGES=(directx9 usp10 msls31 corefonts tahoma win7)
+declare -ra WINE_PACKAGES=(d3dx11_43 usp10 msls31 corefonts tahoma win7)
 declare -ra WINE_SETTINGS=('csmt=on' 'glsl=disabled')
 
 echo "#############################################"

--- a/winebuild.sh
+++ b/winebuild.sh
@@ -1,5 +1,10 @@
 #!/bin/sh
 
+mult32bit_lib_path="/app/lib/32bit/lib"
+
+export LD_LIBRARY_PATH=/app/lib:${mult32bit_lib_path}
+export PATH=${PATH}:/app/lib/32bit/bin
+
 echo ; echo "Configuring 64bit wine" ; echo 
 
 mkdir -p wine_64_build && cd wine_64_build
@@ -26,10 +31,10 @@ cd ..
 echo ; echo "Configuring 32bit wine" ; echo 
 mkdir -p wine_32_build && cd wine_32_build
 
-mkdir -p /app/lib32
+mkdir -p ${mult32bit_lib_path}
                 
 ../configure --prefix=/app \
-             --libdir=/app/lib32 \
+             --libdir=${mult32bit_lib_path} \
              --disable-win16 \
              --with-wine64="../wine_64_build" \
              --with-x \
@@ -47,8 +52,7 @@ make --jobs=$(nproc)
 
 echo ; echo "Installing 32bit wine" ; echo 
 
-make prefix=/app libdir=/app/lib32 dlldir=/app/lib32/wine install || exit 1
-
+make prefix=/app libdir=${mult32bit_lib_path} dlldir=${mult32bit_lib_path}/wine install || exit 1
 
 echo ; echo "Installing 64bit wine" ; echo 
 

--- a/winebuild.sh
+++ b/winebuild.sh
@@ -1,0 +1,57 @@
+#!/bin/sh
+
+echo ; echo "Configuring 64bit wine" ; echo 
+
+mkdir -p wine_64_build && cd wine_64_build
+                
+../configure --prefix=/app \
+             --libdir=/app/lib \
+             --disable-win16 \
+             --enable-win64 \
+             --with-x \
+             --without-cups \
+             --without-curses \
+             --without-capi \
+             --without-glu \
+             --without-gphoto \
+             --without-gsm \
+             --without-hal \
+             --without-ldap \
+             --without-netapi || exit 1
+
+make --jobs=$(nproc)
+
+cd ..
+
+echo ; echo "Configuring 32bit wine" ; echo 
+mkdir -p wine_32_build && cd wine_32_build
+
+mkdir -p /app/lib32
+                
+../configure --prefix=/app \
+             --libdir=/app/lib32 \
+             --disable-win16 \
+             --with-wine64="../wine_64_build" \
+             --with-x \
+             --without-cups \
+             --without-curses \
+             --without-capi \
+             --without-glu \
+             --without-gphoto \
+             --without-gsm \
+             --without-hal \
+             --without-ldap \
+             --without-netapi || exit 1
+
+make --jobs=$(nproc)
+
+echo ; echo "Installing 32bit wine" ; echo 
+
+make prefix=/app libdir=/app/lib32 dlldir=/app/lib32/wine install || exit 1
+
+
+echo ; echo "Installing 64bit wine" ; echo 
+
+cd ../wine_64_build
+
+make prefix=/app libdir=/app/lib dlldir=/app/lib/wine install || exit 1


### PR DESCRIPTION
# Multiarch 64bit Package

The beginning of work on a multiarch package to run 64-bit wine with a [WoW64](https://wiki.winehq.org/Building_Wine#Shared_WoW64) build. It depends on the new work in https://github.com/flatpak/flatpak-builder/pull/129 which supports using extensions during a build.

Once the new functionality is added to [flatpak-builder](https://github.com/flatpak/flatpak-builder), the libraries to build multiarch wine will be able to be added to the build steps

- [x] Add app extension support during build
- [ ] Compile multiarch wine to enable 64-bit Path of Exile